### PR TITLE
Adds property for collections work belongs to

### DIFF
--- a/AO3/works.py
+++ b/AO3/works.py
@@ -212,7 +212,8 @@ class Work:
             "title",
             "warnings",
             "id",
-            "words"
+            "words",
+            "collections"
         )
         string_fields = (
             "date_edited",
@@ -876,6 +877,21 @@ class Work:
 
         chapterStatus = self._soup.find("dd", {"class": "chapters"}).string.split("/")
         return chapterStatus[0] == chapterStatus[1]
+    
+    @cached_property
+    def collections(self):
+        """Returns all the collections the work belongs to
+
+        Returns:
+            list: List of collections
+        """
+
+        html = self._soup.find("dd", {"class": "collections"})
+        collections = []
+        if html is not None:
+            for collection in html.find_all("a"):
+                collections.append(collection.get_text())
+        return collections
     
     def get(self, *args, **kwargs):
         """Request a web page and return a Response object"""  


### PR DESCRIPTION
This change adds a cached property to specify what collections a work currently publicly belongs to.
The addition of cached property is necessary for actually calling the information, but as far as I can tell, the addition of "collections" to the metadata property isn't actually doing anything very important, unless it's to update info while the cached version is static.

Disclaimer: I only started learning python for this addition and a few others to ao3_api, and so this should be double-checked before being added.
